### PR TITLE
Fixes struct.error: 'H' format requires 0 <= number <= 65535

### DIFF
--- a/bin/eazyctrl
+++ b/bin/eazyctrl
@@ -293,7 +293,7 @@ class EazyCommunicator:
             port: Port of the remote device (default: standard modbus port)
             timeout: Time-out for the socket communication with the device.
         """
-        self._transid = random.randrange(0, 2**16)
+        self._transid = random.randrange(0, 2**16-1)
         self._server = server
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.connect((server, port))

--- a/bin/eazyctrl
+++ b/bin/eazyctrl
@@ -293,7 +293,7 @@ class EazyCommunicator:
             port: Port of the remote device (default: standard modbus port)
             timeout: Time-out for the socket communication with the device.
         """
-        self._transid = random.randrange(0, 2**16-1)
+        self._transid = random.randrange(0, 2**16 - 1)
         self._server = server
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.connect((server, port))


### PR DESCRIPTION
Hi, thanks for the library i am using it in a small project and basically it works well.

But i encountered sporadic failures while reading data with `get_variable`:

```python

  File ".../lib/python3.8/site-packages/eazyctrl.py", line 379, in read_variable
    sendmsg['transaction_identifier'] = self._transid
    │                                   │    └ 65536
    │                                   └ <eazyctrl.EazyCommunicator object at 0x7f13b02af8e0>
    └ Modbus03Request(b'\x00\x00\x00\x00\x00\x06\x00\x03\x00\x00\x00\x00')
  File ".../lib/python3.8/site-packages/eazyctrl.py", line 226, in __setitem__
    super().__setitem__(fieldname, fieldvalue)
                        │          └ 65536
                        └ 'transaction_identifier'
  File ".../lib/python3.8/site-packages/eazyctrl.py", line 164, in __setitem__
    byterep = struct.pack(formatstr, fieldvalue)
              │      │    │          └ 65536
              │      │    └ '>H'
              │      └ <built-in function pack>
              └ <module 'struct' from '.../lib/python3.8/struct.py'>

struct.error: 'H' format requires 0 <= number <= 65535
```
https://github.com/baradi09/eazyctrl/blob/fab410fb736e8aca0537bb98b2767c236fad115b/bin/eazyctrl#L296

Could be fixed by:
`self._transid = random.randrange(0, 2**16-1) `